### PR TITLE
pin to 0.7.1 of opentype.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "homepage": "https://github.com/shrhdk/text-to-svg",
   "dependencies": {
     "commander": "^2.9.0",
-    "opentype.js": "^0.7.1"
+    "opentype.js": "0.7.1"
   },
   "devDependencies": {
     "babel-core": "^6.7.2",


### PR DESCRIPTION
@shrhdk,

Thanks for all the work here. Recently I noticed a `Cannot read property 'loadSync' of undefined` error caused by a patch change to `opentype.js`. Pinning `opentype.js` should fix this for the time being.

Regards,
Matthew