### PR TITLE
Fix: builds src on npm pack and publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test:html": "gulp test:html",
     "clean": "gulp clean",
     "lint": "gulp lint",
-    "build": "gulp build"
+    "build": "gulp build",
+    "prepack": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Came across this bug locally and noticed others had the same [issue](https://github.com/shrhdk/text-to-svg/issues/44)

This fix updates npm script to always run the gulp build step during plublishing, ensuring it's avaliability when others npm install