### PR TITLE
create a new function to combine getSVG and getMetrics

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -152,12 +152,16 @@ export default class TextToSVG {
   }
 
   getSVG(text, options = {}) {
+    return this.getSVGAndMetrics(text, options).svg;
+  }
+
+  getSVGAndMetrics(text, options = {}) {
     const metrics = this.getMetrics(text, options);
     let svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="${metrics.width}" height="${metrics.height}">`;
     svg += this.getPath(text, options);
     svg += '</svg>';
 
-    return svg;
+    return { svg, metrics };
   }
 
   getDebugSVG(text, options = {}) {


### PR DESCRIPTION
I had a need to get both the metrics and the SVG string at the same time. Now I could have just called `getSVG` and `getMetrics` in my code and be done with it, but I noticed that `getSVG` actually used `getMetrics` internally so then it would be called twice.

So I thought why not expose a function to get them both at the same time in an efficient manner.
This change is entirely backwards compatible.