### PR TITLE
fix: Updated opentype.js to 1.3.4 to fix support for some fonts

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "homepage": "https://github.com/shrhdk/text-to-svg",
   "dependencies": {
     "commander": "^2.11.0",
-    "opentype.js": "0.11.0"
+    "opentype.js": "1.3.4"
   },
   "devDependencies": {
     "@babel/core": "^7.3.4",


### PR DESCRIPTION
The version of opentype.js this package uses contains a bug that causes a crash when using certain fonts.

For example, calling getPath after loading the [Google font Alexandria](https://fonts.google.com/specimen/Alexandria) causes a crash:

```ts
TextToSVG.loadSync("./alexandria.ttf").getPath("")
```

```
TypeError: Cannot read properties of undefined (reading 'featureIndexes')
    at FeatureQuery.getScriptFeaturesIndexes (.../node_modules/opentype.js/src/features/featureQuery.js:354:16)
    at FeatureQuery.getScriptFeatures (.../node_modules/opentype.js/src/features/featureQuery.js:395:27)
    at FeatureQuery.getFeature (.../node_modules/opentype.js/src/features/featureQuery.js:413:3)
    at .../node_modules/opentype.js/src/font.js:172:7
    at Array.map (<anonymous>)
    at Font.stringToGlyphs (.../node_modules/opentype.js/src/font.js:170:19)
    at TextToSVG.getWidth (.../node_modules/text-to-svg/build/src/index.js:44:30)
    at TextToSVG.getMetrics (.../node_modules/text-to-svg/build/src/index.js:74:24)
    at TextToSVG.getD (.../node_modules/text-to-svg/build/src/index.js:129:26)
    at TextToSVG.getPath (.../node_modules/text-to-svg/build/src/index.js:144:20)
```

The latest version of opentype.js has a fix for this issue implemented: https://github.com/opentypejs/opentype.js/commit/05194b0374b7717f1e275be63463fad6c46542ba

I ran the test and build, everything passes.